### PR TITLE
Deserialize frames directly to frame stack

### DIFF
--- a/examples/combined_copy_serialize.py
+++ b/examples/combined_copy_serialize.py
@@ -2,27 +2,42 @@ import sauerkraut
 import sys
 calls = 0
 
+"""
+In this example, we show an optimization where we skip copies.
+In the `copy_frame` call, we set serialize to True. This will serialize the frame
+and return the bytes, rather than returning a copy of the frame that must be copied later.
+This is important if our locals are large (e.g., numpy arrays).
+
+The call to deserialize_frame is optimized as well with the 'run' flag set to True.
+In this case, the new frame will be directly allocated on Python's frame stack where it can
+be run directly. It is allocated on the frame stack and immediately run, so the returned value is that
+of the wrapped function.
+If run is set to False (the default), the frame will be allocated on the regular heap.
+Before it can be run, it must be copied to the frame stack. This is done by calling sauerkraut.run_frame.
+"""
 
 def fun1(c):
     global calls
     calls += 1
     g = 4
-    frm_copy = sauerkraut.copy_frame(serialize=True)
+    frame_bytes = sauerkraut.copy_frame(serialize=True)
     if calls == 1:
         g = 5
         calls += 1
         hidden_inner = 55
-        return frm_copy
+        return frame_bytes
     else:
         print(f'calls={calls}, c={c}, g={g}')
 
     calls = 0
     return 3
 
-frame = fun1(13)
+
+frame_bytes = fun1(13)
 with open('serialized_frame.bin', 'wb') as f:
-    f.write(frame)
+    f.write(frame_bytes)
 with open('serialized_frame.bin', 'rb') as f:
     read_frame = f.read()
-code = sauerkraut.deserialize_frame(read_frame, run=True)
-print('Done')
+retval = sauerkraut.deserialize_frame(read_frame, run=True)
+
+print('Function returned with:', retval)

--- a/examples/combined_copy_serialize.py
+++ b/examples/combined_copy_serialize.py
@@ -24,9 +24,5 @@ with open('serialized_frame.bin', 'wb') as f:
     f.write(frame)
 with open('serialized_frame.bin', 'rb') as f:
     read_frame = f.read()
-code = sauerkraut.deserialize_frame(read_frame)
-# NEXT: Deserialize and run in-place.
-# code = sauerkraut.deserialize_run_frame(read_frame)
-sauerkraut.run_frame(code)
-
+code = sauerkraut.deserialize_frame(read_frame, run=True)
 print('Done')

--- a/sauerkraut/include/pyref.h
+++ b/sauerkraut/include/pyref.h
@@ -50,6 +50,10 @@ class py_strongref {
         obj = new_obj;
     }
 
+    operator bool() {
+        return obj != NULL;
+    }
+
     static py_strongref steal(T *obj) {
         py_strongref<T> ref;
         ref = obj;
@@ -81,6 +85,10 @@ class py_weakref {
     void operator=(T *new_obj) {
         // always steals
         obj = new_obj;
+    }
+
+    operator bool() {
+        return obj != NULL;
     }
 
     T *operator->() {

--- a/sauerkraut/include/utils.h
+++ b/sauerkraut/include/utils.h
@@ -65,6 +65,25 @@ namespace utils {
             }
         }
 
+        bool ThreadState_HasStackSpace(py_weakref<PyThreadState> state, int size) {
+            return state->datastack_top != NULL && size < state->datastack_limit - state->datastack_top;
+        }
+
+        _PyInterpreterFrame *ThreadState_PushFrame(py_weakref<PyThreadState> tstate, size_t size) {
+            if(!ThreadState_HasStackSpace(tstate, size)) {
+                return NULL;
+            }
+            _PyInterpreterFrame *top = (_PyInterpreterFrame*) tstate->datastack_top;
+            tstate->datastack_top += size;
+            return top;
+        }
+
+        _PyInterpreterFrame *AllocateFrame(size_t size) {
+            return (_PyInterpreterFrame*) malloc(size * sizeof(PyObject*));
+        }
+        _PyInterpreterFrame *AllocateFrame(py_weakref<PyThreadState> tstate, size_t size) {
+            return (_PyInterpreterFrame*) ThreadState_PushFrame(*tstate, size);
+        }
 
         Py_ssize_t get_offset_for_skipping_call() {
             return 5 * sizeof(_CodeUnit);


### PR DESCRIPTION
Now, we can directly allocate deserialized frames to Python's frame stack, where they can be immediately run.
This saves a `malloc` call and a later memory copy when we actually want to run the deserialized frame.