### PR TITLE
Serialize Globals

### DIFF
--- a/examples/resume_globals.py
+++ b/examples/resume_globals.py
@@ -1,0 +1,13 @@
+import sauerkraut as skt
+import greenlet
+import numpy as np
+
+
+def main():
+    with open('serialized_globals_example.bin', 'rb') as f:
+        serialized = f.read()
+    result = skt.deserialize_frame(serialized, run=True)
+    print(result)
+
+if __name__ == "__main__":
+    main()

--- a/examples/with_globals.py
+++ b/examples/with_globals.py
@@ -1,0 +1,21 @@
+import sauerkraut as skt
+import greenlet
+import numpy as np
+
+def fun1():
+    a = np.array([1, 2, 3])
+    a += 1
+    greenlet.getcurrent().parent.switch()
+    a += 1
+    print(f'Mean of a is {np.mean(a)}')
+    return a
+
+def main():
+    gr = greenlet.greenlet(fun1)
+    gr.switch()
+    serialized = skt.copy_frame_from_greenlet(gr, serialize=True)
+    with open('serialized_globals_example.bin', 'wb') as f:
+        f.write(serialized)
+
+if __name__ == "__main__":
+    main()

--- a/sauerkraut/sauerkraut.C
+++ b/sauerkraut/sauerkraut.C
@@ -23,7 +23,7 @@ class sauerkraut_modulestate {
         sauerkraut_modulestate() {
             deepcopy_module = PyImport_ImportModule("copy");
             deepcopy = PyObject_GetAttrString(*deepcopy_module, "deepcopy");
-            pickle_module = PyImport_ImportModule("pickle");
+            pickle_module = PyImport_ImportModule("dill");
             pickle_dumps = PyObject_GetAttrString(*pickle_module, "dumps");
             pickle_loads = PyObject_GetAttrString(*pickle_module, "loads");
         }

--- a/sauerkraut/serdes/include/serdes.h
+++ b/sauerkraut/serdes/include/serdes.h
@@ -350,9 +350,7 @@ namespace serdes {
         offsets::PyInterpreterFrameOffset serialize(Builder &builder, sauerkraut::PyInterpreterFrame &obj, int stack_depth) {
             auto f_executable_ser = code_serializer.serialize(builder, (PyCodeObject*)obj.f_executable.bits);
             auto f_func_obj_ser = po_serializer.serialize(builder, obj.f_funcobj);
-            // for now, we can't do this because of the modules
-            // auto f_globals_ser = po_serializer.serialize(builder, obj.f_globals);
-            // auto f_builtins_ser = po_serializer.serialize(builder, obj.f_builtins);
+            auto f_globals_ser = po_serializer.serialize(builder, obj.f_globals);
 
             auto f_locals_ser = (NULL != obj.f_locals) ? 
                 std::optional{po_serializer.serialize(builder, obj.f_locals)} : std::nullopt;
@@ -362,6 +360,7 @@ namespace serdes {
 
             pyframe_buffer::PyInterpreterFrameBuilder frame_builder(builder);
             frame_builder.add_f_executable(f_executable_ser);
+            frame_builder.add_f_globals(f_globals_ser);
             if(f_locals_ser) {
                 frame_builder.add_f_locals(f_locals_ser.value());
             }


### PR DESCRIPTION
Now Globals are included in the serialized content.
This is important for certain usage scenarios (Charm4Py), where it's not possible to correctly set the globals on
the receiving end.