### PR TITLE
Cache the code on arrival

### DIFF
--- a/sauerkraut/sauerkraut.C
+++ b/sauerkraut/sauerkraut.C
@@ -495,6 +495,13 @@ static void init_code(PyCodeObject *obj, serdes::DeserializedCodeObject &code) {
     obj->_co_monitoring = NULL;
     obj->_co_firsttraceable = 0;
     obj->co_extra = NULL;
+
+    // optimization: cache the co_code_adaptive, which is a result
+    // of PyCode_GetCode, and requires de-optimizing the code.
+    // Here, we will pre-cache, without requiring another de-optimization.
+    obj->_co_cached = PyMem_New(_PyCoCached, 1);
+    std::memset(obj->_co_cached, 0, sizeof(_PyCoCached));
+    obj->_co_cached->_co_code =  PyBytes_FromStringAndSize((const char *)code.co_code_adaptive.data(), code.co_code_adaptive.size());
 }
 
 static PyCodeObject *create_pycode_object(serdes::DeserializedCodeObject& code_obj) {


### PR DESCRIPTION
Now, when we de-serialize a frame, we will pre-cache its code.
When we serialize the frame, we must deoptimize the code, which PyCode_GetCode does for us.
So, when de-serializing, the code is already de-optimized. We'll cache it using PyCodeObject's field for this.

 If we don't do this, Python must de-optimize the code again when we serialize the frame. This makes a difference in when we are serializing and de-serializing the code multiple times (Charm use cases).