### PR TITLE
Ability to replace value of local variables before running frames

### DIFF
--- a/examples/replace_locals.py
+++ b/examples/replace_locals.py
@@ -1,0 +1,28 @@
+import sauerkraut as skt
+import greenlet
+
+def fun1():
+    a = 1
+    b = 2
+    greenlet.getcurrent().parent.switch()
+    return a + b
+
+
+def main():
+    gr1 = greenlet.greenlet(fun1)
+    gr1.switch()
+    print("Back in main")
+    serframe = skt.copy_frame_from_greenlet(gr1, serialize=True)
+    res = skt.deserialize_frame(serframe, replace_locals={'a': 5}, run=True)
+    print(f"The result is {res}")
+
+    deserframe = skt.deserialize_frame(serframe)
+    res = skt.run_frame(deserframe, replace_locals={'a': 9})
+    print(f"The result is {res}")
+
+    deserframe = skt.deserialize_frame(serframe)
+    res = skt.run_frame(deserframe, replace_locals={'b': 35})
+    print(f"The result is {res}")
+
+if __name__ == "__main__":
+    main()

--- a/sauerkraut/include/utils.h
+++ b/sauerkraut/include/utils.h
@@ -360,13 +360,18 @@ namespace utils {
 
             for(auto &[name, local_idx] : local_idx_map) {
                 if(PyDict_Check(replace_locals)) {
-                    PyObject *new_local = PyDict_GetItem(replace_locals, PyUnicode_FromString(name.c_str()));
+                    PyObject *py_string = PyUnicode_FromString(name.c_str());   
+                    PyObject *new_local = PyDict_GetItem(replace_locals, py_string);
+                    Py_DECREF(py_string);
                     if(new_local != NULL) {
                         auto local_index = local_idx_map[name];
                         PyObject *local = (PyObject*) iframe->localsplus[local_index].bits;
-                        Py_DECREF(local);
                         iframe->localsplus[local_index].bits = (intptr_t) new_local;
+
+                        Py_DECREF(local);
+                        Py_DECREF(new_local);
                     }
+
                 }
             }
         }

--- a/test/test.py
+++ b/test/test.py
@@ -127,7 +127,37 @@ def test_greenlet():
     gr.switch(code)
     print("Test 'greenlet' passed")
 
+def replace_locals_fn(c):
+    a = 1
+    b = 2
+    greenlet.getcurrent().parent.switch()
+    return a + b + c
+
+def test_replace_locals():
+    gr = greenlet.greenlet(replace_locals_fn)
+    gr.switch(13)
+    serframe = skt.copy_frame_from_greenlet(gr, serialize=True)
+    code = skt.deserialize_frame(serframe)
+    res = skt.run_frame(code, replace_locals={'a': 9})
+    print(f"The result is {res}")
+    assert res == 24
+
+    serframe = skt.copy_frame_from_greenlet(gr, serialize=True)
+    code = skt.deserialize_frame(serframe)
+    res = skt.run_frame(code, replace_locals={'b': 35})
+    print(f"The result is {res}")
+    assert res == 49
+
+    serframe = skt.copy_frame_from_greenlet(gr, serialize=True)
+    code = skt.deserialize_frame(serframe)
+    res = skt.run_frame(code, replace_locals={'a': 9, 'b': 35, 'c': 100})
+    print(f"The result is {res}")
+    assert res == 144
+
+    print("Test 'replace_locals' passed")
+
 test_copy_then_serialize()
 test_combined_copy_serialize()
 test_for_loop()
 test_greenlet()
+test_replace_locals()


### PR DESCRIPTION
There are a couple reasons we might want to do this.
1. Certain local variables may not be valid in the new context (self, for instance).
2. We can do variable mutation, allowing to tune the value of locals, test, etc.