### PR TITLE
Don't serialize dead locals

### DIFF
--- a/examples/exclude_dead_locals.py
+++ b/examples/exclude_dead_locals.py
@@ -1,0 +1,42 @@
+import sauerkraut as skt
+
+import sauerkraut as skt
+import greenlet
+
+def fun1():
+    a = 1
+    b = 2
+    c = 3
+    for i in range(25):
+        if i > 10:
+            a += 3
+        if i > 2:
+            b += 4
+        if i == 24:
+            # switch only on the final iteration
+            greenlet.getcurrent().parent.switch()
+        if b > 28:
+            print(f"b is {b}")
+    d = 0
+    return a + b + d
+
+
+def main():
+    gr1 = greenlet.greenlet(fun1)
+    gr1.switch()
+    serframe = skt.copy_frame_from_greenlet(gr1, exclude_dead_locals=True, serialize=True)
+    res = skt.deserialize_frame(serframe,run=True, replace_locals={'a': 22, 'c': 35})
+    print(f"The result is {res}")
+
+    # deserframe = skt.deserialize_frame(serframe)
+    # res = skt.run_frame(deserframe, replace_locals={'a': 4, 'c': 5})
+    # print(f"The result is {res}")
+
+    # deserframe = skt.deserialize_frame(serframe)
+    # try:
+    #     res = skt.run_frame(deserframe, replace_locals={'c': 200})
+    # except TypeError as e:
+    #     print("When you forget to replace an excluded local, 'None' is used in its place!")
+
+if __name__ == "__main__":
+    main()

--- a/sauerkraut/__init__.py
+++ b/sauerkraut/__init__.py
@@ -9,6 +9,9 @@ from _sauerkraut import (
     copy_current_frame
 )
 
+from . import liveness
+
+
 __all__ = [
     'copy_and_run_frame',
     'serialize_frame',
@@ -17,5 +20,6 @@ __all__ = [
     'run_frame',
     'resume_greenlet',
     'copy_frame_from_greenlet',
-    'copy_current_frame'
+    'copy_current_frame',
+    'liveness'
 ]

--- a/sauerkraut/__init__.py
+++ b/sauerkraut/__init__.py
@@ -1,4 +1,4 @@
-from _sauerkraut import (
+from ._sauerkraut import (
     copy_and_run_frame,
     serialize_frame,
     copy_frame,

--- a/sauerkraut/include/pyref.h
+++ b/sauerkraut/include/pyref.h
@@ -1,4 +1,4 @@
-#ifndef PYREF_HH_INCLUDED
+ifndef PYREF_HH_INCLUDED
 #define PYREF_HH_INCLUDED
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -37,6 +37,15 @@ class py_strongref {
         return *this;
     }
 
+    py_strongref &operator=(py_strongref &&other) {
+        if (this != &other) {
+            Py_XDECREF((PyObject*) obj);
+            obj = other.obj;
+            other.obj = NULL;
+        }
+        return *this;
+    }
+
     T *operator*() {
         return this->borrow();
     }
@@ -46,6 +55,7 @@ class py_strongref {
     }
 
     void operator=(T *new_obj) {
+        Py_XDECREF((PyObject*) obj);
         // always steals
         obj = new_obj;
     }

--- a/sauerkraut/include/pyref.h
+++ b/sauerkraut/include/pyref.h
@@ -1,4 +1,4 @@
-ifndef PYREF_HH_INCLUDED
+#ifndef PYREF_HH_INCLUDED
 #define PYREF_HH_INCLUDED
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>

--- a/sauerkraut/include/utils.h
+++ b/sauerkraut/include/utils.h
@@ -203,6 +203,13 @@ namespace utils {
            return code->co_nlocals;
        }
 
+       bool set_update(pyobject_weakref set, pyobject_weakref other) {
+            for(auto item : PyIterable(*other)) {
+                PySet_Add(*set, *item);
+            }
+            return true;
+       }
+
      sauerkraut::PyBitcodeInstruction *get_code_adaptive(py_weakref<PyCodeObject> code) {
            return (sauerkraut::PyBitcodeInstruction*) code->co_code_adaptive;
        }

--- a/sauerkraut/liveness.py
+++ b/sauerkraut/liveness.py
@@ -231,6 +231,7 @@ liveness_cache = {}
 
 def get_dead_variables_at_offset(code: types.CodeType, offset: int) -> Set[str]:
     """Get the set of dead variables at a given bytecode offset."""
-    if hash(code) not in liveness_cache:
-        liveness_cache[hash(code)] = LivenessAnalysis(code)
-    return liveness_cache[hash(code)].get_dead_variables_at_offset(offset)
+    h = hash(code.co_name)
+    if h not in liveness_cache:
+        liveness_cache[h] = LivenessAnalysis(code)
+    return liveness_cache[h].get_dead_variables_at_offset(offset)

--- a/sauerkraut/liveness.py
+++ b/sauerkraut/liveness.py
@@ -1,0 +1,198 @@
+import bytecode
+
+from typing import Dict, Set, List, Tuple, Union
+import types
+import bytecode as bc
+from bytecode import Instr, BasicBlock, ControlFlowGraph, Bytecode
+
+_USE_INSTRS = ("LOAD_NAME", "LOAD_FAST")
+_DEF_INSTRS = ("STORE_NAME", "STORE_FAST")
+
+class LivenessAnalysis:
+    def __init__(self, code: Union[types.CodeType, Bytecode, ControlFlowGraph]):
+        """Initialize liveness analysis for Python code.
+        
+        Args:
+            code: Can be a code object, Bytecode, or ControlFlowGraph
+        """
+        if isinstance(code, types.CodeType):
+            self.bytecode = bc.Bytecode.from_code(code)
+            self.cfg = bc.ControlFlowGraph.from_bytecode(self.bytecode)
+        elif isinstance(code, bc.Bytecode):
+            self.bytecode = code
+            self.cfg = bc.ControlFlowGraph.from_bytecode(code)
+        elif isinstance(code, bc.ControlFlowGraph):
+            self.cfg = code
+        else:
+            raise TypeError(f"Expected code, Bytecode, or ControlFlowGraph, got {type(code)}")
+        
+        # Maps from block index to sets of live variables at entry and exit
+        self.block_live_in: Dict[int, Set[str]] = {}
+        self.block_live_out: Dict[int, Set[str]] = {}
+        
+        # Maps from instruction offset to live variables
+        self.offset_to_live_vars: Dict[int, Set[str]] = {}
+        self._instr_offset_set, self._instr_offsets = self._get_instr_offsets()
+        self._localvars = set()
+        
+        # Perform the analysis
+        self._analyze()
+
+    def _get_instr_offsets(self):
+        offsets = []
+        for instr in self.bytecode:
+            if isinstance(instr, Instr):
+                offsets.append(instr.offset)
+        return set(offsets), offsets
+
+    def _is_valid_offset(self, offset: int) -> bool:
+        return offset in self._instr_offset_set
+    
+   
+    def _is_use(self, instr: Instr) -> bool:
+        return instr.name in _USE_INSTRS
+    
+    def _is_def(self, instr: Instr) -> bool:
+        return instr.name in _DEF_INSTRS
+    
+    def _get_uses_and_defs(self, block: BasicBlock) -> Tuple[Set[str], Set[str]]:
+        """Get the variables used and defined in a basic block.
+        
+        Returns:
+            Tuple of (used_vars, defined_vars)
+        """
+        used_vars = set()
+        defined_vars = set()
+        
+        for instr in block:
+            if not isinstance(instr, Instr):
+                continue
+                
+            if self._is_use(instr):
+                if isinstance(instr.arg, str):
+                    used_vars.add(instr.arg)
+            elif self._is_def(instr):
+                if isinstance(instr.arg, str):
+                    defined_vars.add(instr.arg)
+        
+        # Variables that are used before being defined in this block
+        # are considered used by this block
+        return used_vars - defined_vars, defined_vars
+    
+    def _analyze(self):
+        """Perform liveness analysis on the CFG."""
+        # Use block indices instead of block objects as dictionary keys
+        block_indices = {id(block): i for i, block in enumerate(self.cfg)}
+        
+        # Initialize live_in and live_out sets for all blocks
+        self.block_live_in = {i: set() for i in block_indices.values()}
+        self.block_live_out = {i: set() for i in block_indices.values()}
+        
+        # Mapping from block ID to block object for convenience
+        self.blocks_by_id = {id(block): block for block in self.cfg}
+        
+        # Iteratively compute liveness until fixed point
+        changed = True
+        while changed:
+            changed = False
+            
+            # Process blocks in reverse order (backward analysis)
+            for block in reversed(list(self.cfg)):
+                block_idx = block_indices[id(block)]
+                
+                # Compute new live_out as the union of live_in of all successors
+                new_live_out = set()
+                
+                # Add live_in from next_block if it exists
+                if block.next_block:
+                    next_block_idx = block_indices[id(block.next_block)]
+                    new_live_out.update(self.block_live_in[next_block_idx])
+                
+                # Add live_in from jump targets
+                last_instr = None
+                for instr in reversed(block):
+                    if isinstance(instr, Instr):
+                        last_instr = instr
+                        break
+                        
+                if last_instr and last_instr.has_jump():
+                    if isinstance(last_instr.arg, BasicBlock):
+                        target_idx = block_indices[id(last_instr.arg)]
+                        new_live_out.update(self.block_live_in[target_idx])
+                
+                # Check if live_out changed
+                if new_live_out != self.block_live_out[block_idx]:
+                    changed = True
+                    self.block_live_out[block_idx] = new_live_out
+                
+                # Compute new live_in
+                uses, defs = self._get_uses_and_defs(block)
+                new_live_in = uses.union(self.block_live_out[block_idx] - defs)
+                
+                # Check if live_in changed
+                if new_live_in != self.block_live_in[block_idx]:
+                    changed = True
+                    self.block_live_in[block_idx] = new_live_in
+        
+        # Store the block_indices for later use
+        self.block_indices = block_indices
+        
+        # Compute liveness for each instruction within blocks
+        self._compute_instruction_liveness(block_indices)
+
+    def _compute_instruction_liveness(self, block_indices):
+        """Compute liveness information for each instruction within blocks."""
+        # Create a dictionary to map (block_idx, instr_idx) to live variables
+        self.instr_to_live_vars = {}
+        
+        for block in self.cfg:
+            block_idx = block_indices[id(block)]
+            # Start with live variables at block exit
+            live_vars = self.block_live_out[block_idx].copy()
+            
+            # Process instructions in reverse order
+            for i in range(len(block) - 1, -1, -1):
+                instr = block[i]
+                if isinstance(instr, Instr):
+                    # Record live variables at this instruction
+                    if instr.offset is not None:
+                        self.offset_to_live_vars[instr.offset] = live_vars.copy()
+                    
+                    # Also store by block and instruction index
+                    self.instr_to_live_vars[(block_idx, i)] = live_vars.copy()
+                    
+                    # Update live variables based on this instruction
+                    if self._is_def(instr):
+                        if isinstance(instr.arg, str):
+                            live_vars.discard(instr.arg)
+                            self._localvars.add(instr.arg)
+                    
+                    if self._is_use(instr):
+                        if isinstance(instr.arg, str):
+                            live_vars.add(instr.arg)
+                            self._localvars.add(instr.arg)
+    
+    def get_live_variables_at_offset(self, offset: int) -> Set[str]:
+        """Get the set of live variables at a given bytecode offset."""
+        if self._is_valid_offset(offset):
+            if offset in self.offset_to_live_vars:
+                return self.offset_to_live_vars[offset]
+            return set()
+        raise ValueError(f"Invalid offset: {offset}")
+
+    def get_dead_variables_at_offset(self, offset: int) -> Set[str]:
+        """Get the set of dead variables at a given bytecode offset."""
+        live_vars = self.get_live_variables_at_offset(offset)
+        return self._localvars - live_vars
+
+    def get_offsets(self) -> List[int]:
+        """Get the list of instruction offsets."""
+        return self._instr_offsets
+    
+liveness_cache = {}
+
+def get_dead_variables_at_offset(code: types.CodeType, offset: int) -> Set[str]:
+    """Get the set of dead variables at a given bytecode offset."""
+    if hash(code) not in liveness_cache:
+        liveness_cache[hash(code)] = LivenessAnalysis(code)
+    return liveness_cache[hash(code)].get_dead_variables_at_offset(offset)

--- a/sauerkraut/liveness.py
+++ b/sauerkraut/liveness.py
@@ -101,6 +101,8 @@ class LivenessAnalysis:
                     defined_vars.add(arg1)
             elif instr.name == "STORE_FAST_LOAD_FAST":
                 print(f"STORE_FAST_LOAD_FAST: {instr.arg}")
+        
+        return used_vars, defined_vars
     
     def _analyze(self):
         """Perform liveness analysis on the CFG."""

--- a/sauerkraut/sauerkraut.C
+++ b/sauerkraut/sauerkraut.C
@@ -367,7 +367,6 @@ static pyobject_strongref combine_exclusions(py_weakref<PyFrameObject> frame, Py
 static bool apply_exclusions(py_weakref<PyFrameObject> frame, const SerializationOptions& options, 
                             serdes::SerializationArgs& ser_args) {
     auto excluded_vars = combine_exclusions(frame, options.exclude_locals.borrow(), options.exclude_dead_locals);
-    utils::py::print_object(excluded_vars.borrow());
     if (!excluded_vars) {
         return false;
     }

--- a/sauerkraut/sauerkraut.C
+++ b/sauerkraut/sauerkraut.C
@@ -116,8 +116,6 @@ pyobject_strongref get_dead_locals_set(py_weakref<PyFrameObject> frame) {
     pycode_strongref code = pycode_strongref::steal(PyFrame_GetCode(*frame));
     auto offset = utils::py::get_instr_offset<utils::py::Units::Bytes>(frame);
     pyobject_strongref dead_vars = sauerkraut_state->get_dead_variables(code, offset);
-    PySys_WriteStdout("Dead variables: ");
-    utils::py::print_object(*dead_vars);
     return dead_vars;
 }
 

--- a/test/test.py
+++ b/test/test.py
@@ -168,7 +168,7 @@ def exclude_locals_current_frame_fn(c, exclude_locals=None):
     global calls
     calls += 1
     g = 4
-    frame_bytes = skt.copy_current_frame(serialize=True, exclude_locals=exclude_locals)
+    frame_bytes = skt.copy_current_frame(serialize=True, exclude_locals=exclude_locals, exclude_dead_locals=False)
     if calls == 1:
         g = 5
         calls += 1


### PR DESCRIPTION
Sauerkraut currently serializes every local variable that's not explicitly excluded via `exclude_locals`.
This is quite wasteful: we serialize lots of dead locals when we generally only need to serialize the live ones.
One example where you don't want to exclude dead locals: replay debugging, where you may dynamically change liveness.
But in most cases, liveness is static and we can exclude dead locals.