### PR TITLE
Cache invariants

### DIFF
--- a/sauerkraut/include/pyref.h
+++ b/sauerkraut/include/pyref.h
@@ -120,4 +120,9 @@ py_weakref<T> make_weakref(T* ptr) {
     return py_weakref<T>(ptr);
 }
 
+template<typename T>
+py_strongref<T> make_strongref(T* ptr) {
+    return py_strongref<T>(ptr);
+}
+
 #endif

--- a/sauerkraut/sauerkraut.C
+++ b/sauerkraut/sauerkraut.C
@@ -551,19 +551,21 @@ static PyObject *copy_frame(PyObject *self, PyObject *args, PyObject *kwargs) {
     PyObject *frame = NULL;
     SerializationOptions options;
     
-    static char *kwlist[] = {"frame", "exclude_locals", "sizehint", "serialize", "exclude_dead_locals", NULL};
+    static char *kwlist[] = {"frame", "exclude_locals", "sizehint", 
+                             "serialize", "exclude_dead_locals", "exclude_invariants", NULL};
     int serialize = 0;
     PyObject* sizehint_obj = NULL;
     int exclude_dead_locals = 1;
+    int exclude_invariants = 0;
     
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOpp", kwlist, 
-                                    &frame, &options.exclude_locals, &sizehint_obj, &serialize, &exclude_dead_locals)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOppp", kwlist, 
+                                    &frame, &options.exclude_locals, &sizehint_obj, &serialize, &exclude_dead_locals, &exclude_invariants)) {
         return NULL;
     }
     
     options.serialize = (serialize != 0);
     options.exclude_dead_locals = (exclude_dead_locals != 0);
-    
+    options.exclude_invariants = (exclude_invariants != 0);
     if (!parse_sizehint(sizehint_obj, options.sizehint)) {
         return NULL;
     }

--- a/test/test.py
+++ b/test/test.py
@@ -183,7 +183,7 @@ def exclude_locals_current_frame_fn(c, exclude_locals=None):
 def test_exclude_locals_greenlet():
     gr = greenlet.greenlet(exclude_locals_greenletfn)
     gr.switch(13)
-    serframe = skt.copy_frame_from_greenlet(gr, serialize=True, exclude_locals={'a'}, sizehint=500)
+    serframe = skt.copy_frame_from_greenlet(gr, serialize=True, exclude_locals={'a'}, sizehint=500, exclude_invariants=True)
     deserframe = skt.deserialize_frame(serframe)
     try:
         res = skt.run_frame(deserframe)
@@ -195,7 +195,7 @@ def test_exclude_locals_greenlet():
 
     gr2 = greenlet.greenlet(exclude_locals_greenletfn)
     gr2.switch(13)
-    serframe = skt.copy_frame_from_greenlet(gr2, serialize=True, exclude_locals=['c', 'b'])
+    serframe = skt.copy_frame_from_greenlet(gr2, serialize=True, exclude_locals=['c', 'b'], exclude_invariants=True)
     deserframe = skt.deserialize_frame(serframe)
     result = skt.run_frame(deserframe, replace_locals={'c': 100, 'b': 35})
     assert result == 136


### PR DESCRIPTION
Caches 'invariant' or 'immutable' data structures. Things like code, function, and global objects.
These do not need to be serialized when we know the invariants will be the same on the destination as on the source, e.g., like Charm4Py